### PR TITLE
Documentation update

### DIFF
--- a/GameServers/DockerAndGameServers.md
+++ b/GameServers/DockerAndGameServers.md
@@ -67,7 +67,18 @@ The above example is clean but adjusting `+maxplayers` would require modifying t
 docker run -d --net=host lacledeslan/gamesvr-csgo ./srcds_run -game csgo +game_type 0 +game_mode 1 +maxplayers 16 -tickrate 128 +map de_cache +sv_lan 1
 ```
 
-Additionally, by keeping a [CLI](https://en.wikipedia.org/wiki/Command-line_interface) (such as BASH) as the default `ENTRYPOINT` a container can be spun up for interactive testing of internals.
+Additionally, by keeping a [CLI](https://en.wikipedia.org/wiki/Command-line_interface) (such as BASH) within the image, you can exec into a running container, such as this example:
+```shell
+docker exec -it containername bash
+```
+Or you can override the running container default command for troubleshooting purposes:
+
+```shell
+docker run -d --net=host lanparty/gamesvr-csgo bash
+```
+
+as the default `ENTRYPOINT` a container can be spun up for interactive testing of internals.
+
 
 ### Pay Close Attention to File Ownership and Permissions
 

--- a/GameServers/DockerAndGameServers.md
+++ b/GameServers/DockerAndGameServers.md
@@ -71,14 +71,11 @@ Additionally, by keeping a [CLI](https://en.wikipedia.org/wiki/Command-line_inte
 ```shell
 docker exec -it containername bash
 ```
-Or you can override the running container default command for troubleshooting purposes:
+Or you can override the running container default command for troubleshooting purposes and interactive testing of internals:
 
 ```shell
 docker run -d --net=host lanparty/gamesvr-csgo bash
 ```
-
-as the default `ENTRYPOINT` a container can be spun up for interactive testing of internals.
-
 
 ### Pay Close Attention to File Ownership and Permissions
 


### PR DESCRIPTION
Update to the docker documentation, moving away from ENTRYPOINT. Also provides information regarding using exec and executing an interpreter (such as bash) via the command line.